### PR TITLE
Add 'make help' target (Fixes #3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ osbuild_composer_version_x=$(shell echo $(osbuild_composer_version) | sed -e s/v
 weldr_client_version_x=$(shell echo $(weldr_client_version) | sed -e s/v//g)
 
 .PHONY: setup-host
-setup-host:
+setup-host: ## Install all necessary packages on the host system
 	@./bin/setup-host.py container
 
 .PHONY: build/osbuild 
-build/osbuild:
+build/osbuild: ## Build the container for building osbuild rpms
 	@echo "Makefile: build/osbuild: creating $(PREFIX_BUILD)/osbuild:$(osbuild_version)"
 	@podman build \
 		--build-arg osbuild_version=$(osbuild_version) \
@@ -29,7 +29,7 @@ build/osbuild:
 		src/ogsc/build/osbuild 2>&1 > /dev/null
 
 .PHONY: rpms/osbuild 
-rpms/osbuild: build/osbuild
+rpms/osbuild: build/osbuild ## Build the rpms for osbuild
 	@echo "Makefile: rpms/osbuild: creating rpms for osbuild ${osbuild_version}"
 	@ls $(shell pwd)/build/rpms/osbuild-$(osbuild_version_x)-*.rpm > /dev/null || podman run \
 		--rm \
@@ -38,7 +38,7 @@ rpms/osbuild: build/osbuild
 		make rpm 2>&1 > /dev/null
 
 .PHONY: build/osbuild-composer
-build/osbuild-composer:
+build/osbuild-composer: ## Build the container for building osbuild-composer rpms
 	@echo "Makefile: build/osbuild-composer: creating $(PREFIX_BUILD)/osbuild-composer:$(osbuild_composer_version)"
 	@podman build \
 		--build-arg osbuild_composer_version=$(osbuild_composer_version) \
@@ -46,7 +46,7 @@ build/osbuild-composer:
 		src/ogsc/build/osbuild-composer 2>&1 > /dev/null
 
 .PHONY: rpms/osbuild-composer
-rpms/osbuild-composer: build/osbuild-composer
+rpms/osbuild-composer: build/osbuild-composer ## Build the rpms for osbuild-composer
 	@echo "Makefile: rpms/osbuild-composer: creating rpms for osbuild-composer ${osbuild_composer_version}"
 	@ls $(shell pwd)/build/rpms/osbuild-composer-$(osbuild_composer_version_x)-* > /dev/null || podman run \
 		--rm \
@@ -55,7 +55,7 @@ rpms/osbuild-composer: build/osbuild-composer
 		make scratch 2>&1 > /dev/null
 
 .PHONY: config/osbuild-composer
-config/osbuild-composer: build/osbuild-composer
+config/osbuild-composer: build/osbuild-composer ## Configure the osbuild-composer container (include test data, generate certs etc)
 	@podman run \
 		--rm \
 		--volume $(shell pwd)/build/rpms/:/build/osbuild-composer/rpmbuild/RPMS/x86_64/:rw,Z \
@@ -64,7 +64,7 @@ config/osbuild-composer: build/osbuild-composer
 		bash -c './tools/gen-certs.sh ./test/data/x509/openssl.cnf /build/config /build/config/ca 2>&1 > /dev/null && cp ./test/data/composer/osbuild-composer.toml /build/config && cp ./test/data/worker/osbuild-worker.toml /build/config && cp -r ./repositories /build/config' 2>&1 > /dev/null
 
 .PHONY: build/weldr-client
-build/weldr-client:
+build/weldr-client: ## Build the container for building the weldr-client rpms
 	@echo "Makefile: build/weldr-client: creating $(PREFIX_BUILD)/weldr-client:$(weldr_client_version)"
 	@podman build \
 		--build-arg weldr_client_version=$(weldr_client_version) \
@@ -72,7 +72,7 @@ build/weldr-client:
 		src/ogsc/build/weldr-client 2>&1 > /dev/null
 
 .PHONY: rpms/weldr-client
-rpms/weldr-client: build/weldr-client
+rpms/weldr-client: build/weldr-client ## Build the rpms for weldr-client
 	@echo "Makefile: rpms/weldr-client: creating rpms for weldr-client $(weldr_client_version)"
 	@ls $(shell pwd)/build/rpms/weldr-client-$(weldr_client_version_x)-* > /dev/null || podman run \
 		--rm \
@@ -81,7 +81,7 @@ rpms/weldr-client: build/weldr-client
 		make scratch-rpm 2>&1 > /dev/null
 
 .PHONY: run/composer
-run/composer:
+run/composer: # Launch the osbuild-composer container
 	@echo "Makefile: run/composer: creating $(PREFIX_RUN)/composer:$(osbuild_composer_version)"
 	@podman build \
 		--volume $(shell pwd)/build/rpms:/rpms:ro,Z \
@@ -90,7 +90,7 @@ run/composer:
 		src/ogsc/run/composer 2>&1 > /dev/null
 
 .PHONY: run/worker
-run/worker:
+run/worker: ## Launch the worker container
 	@echo "Makefile: run/worker: creating $(PREFIX_RUN)/worker:$(osbuild_composer_version)_$(osbuild_version)"
 	@podman build \
 		--volume $(shell pwd)/build/rpms:/rpms:ro,Z \
@@ -100,7 +100,7 @@ run/worker:
 		src/ogsc/run/worker 2>&1 > /dev/null
 
 .PHONY: run/cli
-run/cli:
+run/cli: ## Launch the weldr-client container
 	@echo "Makefile: run/cli: creating $(PREFIX_RUN)/cli:$(weldr_client_version)"
 	@podman build \
 		--volume $(shell pwd)/build/rpms:/rpms:ro,Z \
@@ -109,14 +109,15 @@ run/cli:
 		src/ogsc/run/cli 2>&1 > /dev/null
 
 .PHONY: quick
-quick: rpms/osbuild rpms/osbuild-composer rpms/weldr-client config/osbuild-composer run/composer run/worker run/cli
+quick: ## Like 'run', but quick!
+	rpms/osbuild rpms/osbuild-composer rpms/weldr-client config/osbuild-composer run/composer run/worker run/cli
 
 .PHONY: run
-run: config/osbuild-composer quick
+run: config/osbuild-composer quick ## Launch the whole stack
 	@./bin/run.py ${osbuild_version} ${osbuild_composer_version} ${weldr_client_version}
 
 .PHONY: clean
-clean:
+clean: ## Remove containers and rpms
 	podman image ls "ogsc/build/osbuild" || podman image rm -f $(shell podman image ls "ogsc/build/osbuild" -q)
 	podman image ls "ogsc/build/osbuild-composer" || podman image rm -f $(shell podman image ls "ogsc/build/osbuild-composer" -q)
 	podman image ls "ogsc/build/weldr-client" || podman image rm -f $(shell podman image ls "ogsc/build/weldr-client" -q)
@@ -124,3 +125,7 @@ clean:
 	podman image ls "ogsc/run/worker" || podman image rm -f $(shell podman image ls "ogsc/run/worker" -q)
 	podman image ls "ogsc/run/cli" || podman image rm -f $(shell podman image ls "ogsc/run/cli" -q)
 	rm $(shell pwd)/build/rpms/*.rpm
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_\/-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
So obviously this approach has been done by others on the interwebs before me, but I like it for the way it keeps docs and code together.
Let me know if you like it or if you prefer some other way of documenting the targets!

Also, the `help` target could become the default (i.e. when calling `make` without target).