### PR TITLE
service/config: Create `/config` directory

### DIFF
--- a/service/config/Dockerfile-config
+++ b/service/config/Dockerfile-config
@@ -1,6 +1,7 @@
 FROM fedora:38
 
 RUN dnf install -y openssl
+RUN mkdir -p /config
 
 COPY ./tools/gen-certs.sh .
 COPY ./config/x509/openssl.cnf .


### PR DESCRIPTION
`docker compose build` command was failing with following error: `mkdir: cannot create directory '/config': Not a directory.`

This adds a command to create the directory in advance, which fixes the error.